### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tasks.
 
 - do not try to invent new set of high level programming abstractions
   (yet): use a low level programming model (IPython.parallel) to finely
-  control the cluster elements and messages transfered and help identify
+  control the cluster elements and messages transferred and help identify
   what are the practical underlying constraints in distributed machine
   learning setting.
 

--- a/pyrallel/model_selection.py
+++ b/pyrallel/model_selection.py
@@ -90,7 +90,7 @@ class RandomizedGridSeach(TaskManager):
         # Abort any other previously scheduled tasks
         self.abort()
 
-        # Schedule a new batch of evalutation tasks
+        # Schedule a new batch of evaluation tasks
         self.task_groups, self.all_parameters = [], []
 
         # Collect temporary files:


### PR DESCRIPTION
There are small typos in:
- README.md
- pyrallel/model_selection.py

Fixes:
- Should read `transferred` rather than `transfered`.
- Should read `evaluation` rather than `evalutation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md